### PR TITLE
Cleaned up main.go 

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,7 +116,3 @@ func main() {
 	fmt.Println("Server running on http://localhost:8088")
 	r.Run(":8088")
 }
-
-func getUseRemoteDb() bool {
-	return useRemoteDB
-}


### PR DESCRIPTION
This pull request includes a small change to the `main.go` file. The change removes an unused function `getUseRemoteDb` from the codebase.

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L119-L122): Removed the `getUseRemoteDb` function as it was not being used.