### PR TITLE
Updated websites document title to appropriate titles

### DIFF
--- a/public/html/error.html
+++ b/public/html/error.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Error</title>
     <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body>

--- a/public/html/index.html
+++ b/public/html/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Cloudmesh</title>
     <link rel="stylesheet" href="/css/styles.css">
 <body>
 

--- a/public/html/launcherdownload.html
+++ b/public/html/launcherdownload.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Genesis -> Download -> Launcher</title>
+    <title>Cloudmesh -> Launcher</title>
     <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body>

--- a/public/html/login.html
+++ b/public/html/login.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Cloudmesh -> Login</title>
     <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body>

--- a/public/html/news.html
+++ b/public/html/news.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Cloudmesh -> Login</title>
     <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body>

--- a/public/html/register.html
+++ b/public/html/register.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Cloudmesh -> Register</title>
     <link rel="stylesheet" href="/css/styles.css">
 </head>
 <body>


### PR DESCRIPTION
This pull request includes changes to the titles of several HTML files to provide more descriptive and specific titles. The most important changes include updating the titles for error, index, launcher download, login, news, and register pages.

Changes to HTML titles:

* [`public/html/error.html`](diffhunk://#diff-13ab55d4f5330f561c125a5a5152a553d70243fb62f5ad7b5e17183785e31033L6-R6): Changed the title from "Document" to "Error".
* [`public/html/index.html`](diffhunk://#diff-38e29da721453f95d159af9d329ee6367d2ac983fe4eb2b1a63108a96a138c75L6-R6): Changed the title from "Document" to "Cloudmesh".
* [`public/html/launcherdownload.html`](diffhunk://#diff-99dada032c54f12388af1c5fa7a8540318305ebd8bd11b1ee4923ae0238c3604L6-R6): Changed the title from "Genesis -> Download -> Launcher" to "Cloudmesh -> Launcher".
* [`public/html/login.html`](diffhunk://#diff-990d7cf929c35e5ac37a3bf7a5ad215a65752a35b86042241a6667eea77ad53bL6-R6): Changed the title from "Document" to "Cloudmesh -> Login".
* [`public/html/news.html`](diffhunk://#diff-f110b681aeabd109a019f7ea708d11a929fc0366436014f9f464b1ad42c3a7c4L6-R6): Changed the title from "Document" to "Cloudmesh -> Login".
* [`public/html/register.html`](diffhunk://#diff-b0318777d7b91cb91e67dcd05d917780db69a928f39d39cc36b7240d6be14cdeL6-R6): Changed the title from "Document" to "Cloudmesh -> Register".